### PR TITLE
Fix Elasticsearch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/OpenAddressesUK/mongoid_address_models.git
-  revision: a5abd1ba9dd7ffa994e5390424d3fedc5e3265ec
+  revision: c6bfc3c047a6794426085149b8a5ab52b693e0b3
   specs:
     mongoid_address_models (0.0.1)
       mongoid

--- a/lib/sorting_office.rb
+++ b/lib/sorting_office.rb
@@ -5,10 +5,6 @@ Dotenv.load
 
 require 'mongoid_address_models/require_all'
 
-if ENV["BONSAI_URL"]
-  Mongoid::Elasticsearch.client_options = { url: ENV["BONSAI_URL"] }
-end
-
 Mongoid.load!(File.join(File.dirname(__FILE__), "..", "config", "mongoid.yml"), ENV["MONGOID_ENVIRONMENT"] || :development)
 
 require 'sorting_office/models/street'


### PR DESCRIPTION
I've moved the config to the mongoid_address_models gem (pushed to master like a BOSS), and added the relevant env to Heroku (using `ELASTICSEARCH_URL`, rather than `BONSAI_URL` to be more general.

We had to run the town and locality indexes again, presumably because when we upgraded it blew everything away, but this works now.
