### PR TITLE
Submission guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you'd like to submit the address you're using to the OpenAddresses project, t
 
     curl --data "address=10 Downing Street, London, SW1A 2AA&contribute=true" http://sorting-office.openaddressesuk.org/address
 
-Please make sure you check with your users first! And be sure not to violate others' intellectual property or privacy rights with your submission.
+If you choose to take this option then you must comply with our <a href='#subguidelines'>submission guidelines</a>.
 
 You'd get the following response in JSON format:
 
@@ -125,3 +125,16 @@ We have another set of tests, which we know don't all pass. This takes some of t
     rspec spec/big_old_list_spec.rb
 
 And watch the fail! Currently there are 8 failing tests out of 25 in total.
+
+<h2 id='subguidelines'>Submission Guidelines</h2>
+
+We do not want to receive any names in the submission, other than any company name that may form part of the address. The Open Addresses data that we publish will be about locations, not about people.
+
+Do not worry about the format of the address. The platform is designed and built to support many different formats.
+
+Please be sure not to violate others' intellectual property or privacy rights with your submission. If you think your Intellectual Property rights are being infringed then please [report the infringement](https://alpha.openaddressesuk.org/about/reportaninfringement).
+
+When you submit an address we will capture some additional information: specifically the IP address that you are currently using. This information is used to track submissions and as part of our processes to track provenance and to remove any data that is unlawful. Find out more about our [privacy policy](https://alpha.openaddressesuk.org/about/data/privacy).
+
+By submitting an address you are saying that Open Addresses Limited can re-use the address and publish it under an open data licence. You are saying that the publication of the address by Open Addresses Limited or third parties does not and will not infringe any of your legal rights or those of any third party.
+


### PR DESCRIPTION
Quick hack to add in submission guidelines as per the front page.

https://github.com/OpenAddressesUK/roadmap/issues/79 should add a better solution to save duplicated text that gets sync out of.
