### PR TITLE
Remove everything after the postcode

### DIFF
--- a/lib/sorting_office/address.rb
+++ b/lib/sorting_office/address.rb
@@ -21,7 +21,11 @@ module SortingOffice
 
     def get_postcode
       @postcode = Postcode.calculate(@address)
-      @address = @address.gsub(/#{@postcode.name.gsub(' ', ' ?')}/i, "") if @postcode
+      if @postcode
+        regex = @postcode.name.gsub(' ', ' ?')
+        @address = @address[/^.+#{regex}/i] # Remove anything after the postcode
+        @address = @address.gsub(/#{regex}/i, "")
+      end
     end
 
     def get_town

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -17,6 +17,13 @@ describe SortingOffice::Address do
     expect(address.address).to_not match /EC2A 4JE/
   end
 
+  it "removes the everything after the postcode after parsing" do
+    address = SortingOffice::Address.new("3rd Floor, 65 Clifton Street, London EC2A 4JE Tel: 123456789 Fax: 9483442323")
+    address.get_postcode
+
+    expect(address.address).to_not match /Tel: 123456789 Fax: 9483442323/
+  end
+
   it "removes the postcode after if lowercase" do
     address = SortingOffice::Address.new("3rd Floor, 65 Clifton Street, London ec2a 4je")
     address.get_postcode


### PR DESCRIPTION
Fixes #21

I think the two issues described in #21 are edge cases caused by duff data, but this will remove everything after the postcode, meaning if we do have someone accidentally adding a phone number or whatever, it won't get added.
